### PR TITLE
Closes #132. Fixed rotation by checking for saved instance state, but…

### DIFF
--- a/app-refresh/src/main/java/com/androidessence/cashcaretaker/main/MainActivity.kt
+++ b/app-refresh/src/main/java/com/androidessence/cashcaretaker/main/MainActivity.kt
@@ -30,7 +30,11 @@ class MainActivity : AppCompatActivity(), MainController, FragmentManager.OnBack
         setSupportActionBar(toolbar)
 
         supportFragmentManager.addOnBackStackChangedListener(this)
-        showAccounts()
+        initializeBackButton()
+
+        if (savedInstanceState == null) {
+            showAccounts()
+        }
     }
 
     override fun navigateToAddAccount() {
@@ -79,11 +83,18 @@ class MainActivity : AppCompatActivity(), MainController, FragmentManager.OnBack
     }
 
     override fun onBackStackChanged() {
-        val shouldShowUp = supportFragmentManager.backStackEntryCount > 1
-        supportActionBar?.setDisplayHomeAsUpEnabled(shouldShowUp)
+        initializeBackButton()
 
         when (supportFragmentManager.getBackStackEntryAt(supportFragmentManager.backStackEntryCount - 1).name) {
             AccountFragment.FRAGMENT_NAME -> supportActionBar?.setTitle(R.string.app_name)
         }
+    }
+
+    /**
+     * Checks the size of the back stack and sets the visibility of the back button if necessary.
+     */
+    private fun initializeBackButton() {
+        val shouldShowUp = supportFragmentManager.backStackEntryCount > 1
+        supportActionBar?.setDisplayHomeAsUpEnabled(shouldShowUp)
     }
 }

--- a/app-refresh/src/main/java/com/androidessence/cashcaretaker/transaction/TransactionFragment.kt
+++ b/app-refresh/src/main/java/com/androidessence/cashcaretaker/transaction/TransactionFragment.kt
@@ -49,7 +49,6 @@ class TransactionFragment : BaseFragment() {
         super.onCreate(savedInstanceState)
 
         readArguments()
-        setupTitle()
         viewModel = ViewModelProviders.of(this, viewModelFactory).get(TransactionViewModel::class.java)
         subscribeToAdapter()
         subscribeToViewModel()
@@ -64,6 +63,7 @@ class TransactionFragment : BaseFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        setupTitle()
 
         initializeRecyclerView()
 


### PR DESCRIPTION
… also initializing the backbutton on recreation. Also had to update the transactions page to show the title every time it resumed.